### PR TITLE
FEAT: add support for elastalert 0.2.4 to support es7

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,11 @@ RUN apk add --update --no-cache ca-certificates openssl-dev openssl python3-dev 
 WORKDIR "${ELASTALERT_HOME}"
 
 # This is needed to fix Only timezones from the pytz library are supported - https://github.com/Yelp/elastalert/issues/2968
-RUN cat setup.py && sed -i "s/install_requires\=\[/install_requires\=\[\'tzlocal\<3.0\\',/" setup.py && cat setup.py
+# Dependencies are coming from https://github.com/Yelp/elastalert/blob/master/requirements.txt
+RUN cat setup.py && \
+  sed -i "s/install_requires\=\[/install_requires\=\[\'tzlocal\<3.0\\',/" setup.py && \
+  sed -i "s/'PyYAML>=3.12'/'PyYAML>=5.1'/" setup.py && \
+  cat setup.py
 RUN python3 setup.py install
 
 FROM node:alpine

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-FROM alpine:latest as py-ea
-ARG ELASTALERT_VERSION=v0.2.0b2
+FROM alpine:3.12.3 as py-ea
+ARG ELASTALERT_VERSION=v0.2.4
 ENV ELASTALERT_VERSION=${ELASTALERT_VERSION}
 # URL from which to download Elastalert.
 ARG ELASTALERT_URL=https://github.com/Yelp/elastalert/archive/$ELASTALERT_VERSION.zip
@@ -9,7 +9,7 @@ ENV ELASTALERT_HOME /opt/elastalert
 
 WORKDIR /opt
 
-RUN apk add --update --no-cache ca-certificates openssl-dev openssl python2-dev python2 py2-pip py2-yaml libffi-dev gcc musl-dev wget && \
+RUN apk add --update --no-cache ca-certificates openssl-dev openssl python3-dev python3 py3-pip py3-yaml libffi-dev gcc musl-dev wget && \
 # Download and unpack Elastalert.
     wget -O elastalert.zip "${ELASTALERT_URL}" && \
     unzip elastalert.zip && \
@@ -18,20 +18,19 @@ RUN apk add --update --no-cache ca-certificates openssl-dev openssl python2-dev 
 
 WORKDIR "${ELASTALERT_HOME}"
 
-# Install Elastalert.
-# see: https://github.com/Yelp/elastalert/issues/1654
-RUN sed -i 's/jira>=1.0.10/jira>=1.0.10,<1.0.15/g' setup.py && \
-    python setup.py install && \
-    pip install -r requirements.txt
+# This is needed to fix Only timezones from the pytz library are supported - https://github.com/Yelp/elastalert/issues/2968
+RUN cat setup.py && sed -i "s/install_requires\=\[/install_requires\=\[\'tzlocal\<3.0\\',/" setup.py && cat setup.py
+RUN python3 setup.py install
 
 FROM node:alpine
 LABEL maintainer="BitSensor <dev@bitsensor.io>"
 # Set timezone for this container
 ENV TZ Etc/UTC
 
-RUN apk add --update --no-cache curl tzdata python2 make libmagic
+RUN apk add --update --no-cache curl tzdata python3 make libmagic && \
+    ln -s /usr/bin/python3 /usr/bin/python
 
-COPY --from=py-ea /usr/lib/python2.7/site-packages /usr/lib/python2.7/site-packages
+COPY --from=py-ea /usr/lib/python3.8/site-packages /usr/lib/python3.8/site-packages
 COPY --from=py-ea /opt/elastalert /opt/elastalert
 COPY --from=py-ea /usr/bin/elastalert* /usr/bin/
 

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,9 @@
-v ?= v0.2.0b2
+v ?= v0.2.4
 
 all: build
 
 build:
-	docker pull alpine:latest && docker pull node:alpine
+	docker pull alpine:3.12.3 && docker pull node:alpine
 	docker build --build-arg ELASTALERT_VERSION=$(v) -t elastalert .
 
 server: build

--- a/config/config.json
+++ b/config/config.json
@@ -3,7 +3,7 @@
   "port": 3030,
   "wsport": 3333,
   "elastalertPath": "/opt/elastalert",
-  "verbose": false,
+  "verbose": true,
   "es_debug": false,
   "debug": false,
   "rulesPath": {
@@ -14,7 +14,7 @@
     "relative": true,
     "path": "/rule_templates"
   },
-  "es_host": "elasticsearch",
-  "es_port": 9200,
+  "es_host": "log.corp.reva.tech",
+  "es_port": 443,
   "writeback_index": "elastalert_status"
 }

--- a/config/elastalert-test.yaml
+++ b/config/elastalert-test.yaml
@@ -1,11 +1,9 @@
-# NOTE: This config is used when testing a rule
-
 # The elasticsearch hostname for metadata writeback
 # Note that every rule can have its own elasticsearch host
-es_host: localhost
+es_host: log.corp.reva.tech
 
 # The elasticsearch port
-es_port: 9200
+es_port: 443
 
 # This is the folder that contains the rule yaml files
 # Any .yaml file will be loaded as a rule
@@ -14,21 +12,21 @@ rules_folder: rules
 # How often ElastAlert will query elasticsearch
 # The unit can be anything from weeks to seconds
 run_every:
-  seconds: 5
+  minutes: 1
 
 # ElastAlert will buffer results from the most recent
 # period of time, in case some log sources are not in real time
 buffer_time:
-  minutes: 1
+  minutes: 2
 
 # Optional URL prefix for elasticsearch
 #es_url_prefix: elasticsearch
 
 # Connect with TLS to elasticsearch
-#use_ssl: True
+use_ssl: True
 
 # Verify TLS certificates
-#verify_certs: True
+verify_certs: True
 
 # GET request with body is the default option for Elasticsearch.
 # If it fails for some reason, you can pass 'GET', 'POST' or 'source'.
@@ -48,4 +46,4 @@ writeback_index: elastalert_status
 # If an alert fails for some reason, ElastAlert will retry
 # sending the alert until this time period has elapsed
 alert_time_limit:
-  days: 2
+  days: 1

--- a/config/elastalert.yaml
+++ b/config/elastalert.yaml
@@ -1,9 +1,9 @@
 # The elasticsearch hostname for metadata writeback
 # Note that every rule can have its own elasticsearch host
-es_host: localhost
+es_host: log.corp.reva.tech
 
 # The elasticsearch port
-es_port: 9200
+es_port: 443
 
 # This is the folder that contains the rule yaml files
 # Any .yaml file will be loaded as a rule
@@ -12,21 +12,21 @@ rules_folder: rules
 # How often ElastAlert will query elasticsearch
 # The unit can be anything from weeks to seconds
 run_every:
-  seconds: 5
+  minutes: 1
 
 # ElastAlert will buffer results from the most recent
 # period of time, in case some log sources are not in real time
 buffer_time:
-  minutes: 1
+  minutes: 2
 
 # Optional URL prefix for elasticsearch
 #es_url_prefix: elasticsearch
 
 # Connect with TLS to elasticsearch
-#use_ssl: True
+use_ssl: True
 
 # Verify TLS certificates
-#verify_certs: True
+verify_certs: True
 
 # GET request with body is the default option for Elasticsearch.
 # If it fails for some reason, you can pass 'GET', 'POST' or 'source'.
@@ -46,4 +46,4 @@ writeback_index: elastalert_status
 # If an alert fails for some reason, ElastAlert will retry
 # sending the alert until this time period has elapsed
 alert_time_limit:
-  days: 2
+  days: 1


### PR DESCRIPTION
The [elastalert](https://github.com/Yelp/elastalert) guys recommend the bitsensor docker image [](https://github.com/Yelp/elastalert#docker)

Elasticsearch 7 support was added with version 0.2.0b and it looks like the bitsensor company has went under so the repository has not been updated to use the latest elastalert and also python3.
https://github.com/Yelp/elastalert/issues/2202

This PR will add support python3 and elastelart version [0.2.4](https://github.com/Yelp/elastalert/tags) which is the latest stable release. This is based on this existing PR on the bitsensor repo.
https://github.com/bitsensor/elastalert/pull/157/files

There was an additional issue found while updating to python3:
https://github.com/Yelp/elastalert/issues/2968
Which is fixed in the Dockerfile here: https://github.com/Redisrupt/elastalert/compare/master...robvelor:build-0.2.4?expand=1#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557R22
